### PR TITLE
Spec both pull requests and merge queue as trigger events.

### DIFF
--- a/.github/workflows/formatCode.yaml
+++ b/.github/workflows/formatCode.yaml
@@ -1,7 +1,8 @@
 name: Code Quality checks
 on:
-  # pull_request:
-  #   branches: [main]
+  # does this require both pull_request and merge_group events?
+  pull_request:
+    branches: [main]
 
   merge_group:
     types: [checks_requested]


### PR DESCRIPTION
Based on information from here:

https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks

It seems like, when wanting to run status checks before PR merges, need to combine both the `merge_queue` and `pull_request` events.